### PR TITLE
Xblit optimisations

### DIFF
--- a/src/sdl12main.c
+++ b/src/sdl12main.c
@@ -73,18 +73,30 @@ static const SDL_Color base_palette[16] =
 };
 
 static SDL_Color palette[16];
+static Uint32 map[16];
 
-static inline Uint32 getcolor(char idx)
+#define getcolor(col) map[col % 16]
+
+static void SetPaletteEntry(char idx, char base_idx)
 {
-    SDL_Color c = palette[idx%16];
-    return SDL_MapRGB(screen->format, c.r,c.g,c.b);
+    palette[idx] = base_palette[base_idx];
+    map[idx] = SDL_MapRGB(screen->format, palette[idx].r, palette[idx].g, palette[idx].b);
+}
+
+static void RefreshPalette(void)
+{
+    int i;
+
+    for (i = 0; i < SDL_arraysize(map); i++)
+    {
+        map[i] = SDL_MapRGB(screen->format, palette[i].r, palette[i].g, palette[i].b);
+    }
 }
 
 static void ResetPalette(void)
 {
-    //SDL_SetPalette(surf, SDL_PHYSPAL|SDL_LOGPAL, (SDL_Color*)base_palette, 0, 16);
-    //memcpy(screen->format->palette->colors, base_palette, 16*sizeof(SDL_Color));
     SDL_memcpy(palette, base_palette, sizeof palette);
+    RefreshPalette();
 }
 
 static char* GetDataPath(char* path, int n, const char* fname)
@@ -582,6 +594,7 @@ static void mainLoop(void)
                         OSDset("toggle fullscreen");
                     }
                     screen = SDL_GetVideoSurface();
+                    RefreshPalette();
                     break;
                 }
                 else if (0 && ev.key.keysym.sym == SDLK_5)
@@ -1011,7 +1024,7 @@ int pico8emu(CELESTE_P8_CALLBACK_TYPE call, ...) {
             if (a >= 0 && a < 16 && b >= 0 && b < 16)
             {
                 //swap palette colors
-                palette[a] = base_palette[b];
+                SetPaletteEntry(a, b);
             }
             break;
         }

--- a/src/sdl20compat.inc.c
+++ b/src/sdl20compat.inc.c
@@ -7,6 +7,7 @@ enum
     SDL_LOGPAL      = 2,
     SDL_SRCCOLORKEY = 4,
     SDL_HWPALETTE   = 8,
+    SDL_ANYFORMAT   = 16,
 };
 
 static SDL_Surface*  sdl2_screen     = NULL;
@@ -20,7 +21,7 @@ static SDL_Texture* ngage_frame = NULL;
 
 static SDL_Surface *SDL_SetVideoMode(int width, int height, int bpp, Uint32 flags)
 {
-    Uint32 format = SDL_PIXELFORMAT_RGBA32;
+    Uint32 format = SDL_PIXELFORMAT_UNKNOWN;
     SDL_RendererInfo info = { 0 };
     unsigned int i;
 
@@ -47,11 +48,19 @@ static SDL_Surface *SDL_SetVideoMode(int width, int height, int bpp, Uint32 flag
         }
 
         for (i = 0; i < info.num_texture_formats; i++) {
-            if (SDL_BYTESPERPIXEL(info.texture_formats[i]) == 4) {
+            int found_bpp = SDL_BYTESPERPIXEL(info.texture_formats[i]);
+            if (found_bpp * 8 == bpp) {
                 format = info.texture_formats[i];
                 break;
+            } else if ((flags & SDL_ANYFORMAT) && format == SDL_PIXELFORMAT_UNKNOWN) {
+                if (found_bpp == 2 || found_bpp == 4) {
+                    format = info.texture_formats[i];
+                }
             }
         }
+        if (format == SDL_PIXELFORMAT_UNKNOWN)
+            format = SDL_PIXELFORMAT_RGBA32;
+
         sdl2_screen_tex = SDL_CreateTexture(sdl2_rendr, format, SDL_TEXTUREACCESS_STREAMING, width, height);
 
         if (0)


### PR DESCRIPTION
The first commit is a follow-up to PR #5. The second commit avoids calling SDL_MapRGB repeatedly in inner loops.