### PR TITLE
N3DS: Build mixer with Tremor backend in CI.

### DIFF
--- a/.github/workflows/n3ds.yml
+++ b/.github/workflows/n3ds.yml
@@ -38,7 +38,7 @@ jobs:
           cmake -S .github/SDL_mixer -B .github/SDL_mixer-build -DCMAKE_TOOLCHAIN_FILE=$DEVKITPRO/cmake/3DS.cmake \
                 -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DSDL2MIXER_DEPS_SHARED=OFF \
                 -DSDL2MIXER_SAMPLES=OFF -DSDL2MIXER_FLAC=OFF -DSDL2MIXER_MIDI=OFF -DSDL2MIXER_MOD=OFF \
-                -DSDL2MIXER_MP3=OFF -DSDL2MIXER_OPUS=OFF
+                -DSDL2MIXER_MP3=OFF -DSDL2MIXER_OPUS=OFF -DSDL2MIXER_VORBIS=TREMOR
           cmake --build .github/SDL_mixer-build --config ${{ env.BUILD_TYPE }}
           cmake --install .github/SDL_mixer-build --config ${{ env.BUILD_TYPE }}
 
@@ -48,7 +48,8 @@ jobs:
                 -B build \
                 -DCMAKE_TOOLCHAIN_FILE=$DEVKITPRO/cmake/3DS.cmake \
                 -D CMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
-                -D CELESTE_P8_ENABLE_AUDIO=ON
+                -D CELESTE_P8_ENABLE_AUDIO=ON \
+                -D tremor_LINK_LIBRARIES=$DEVKITPRO/portlibs/3ds/lib/libogg.a
 
       - name: Build project
         run: cmake --build build --config ${{ env.BUILD_TYPE }}


### PR DESCRIPTION
## Description

This PR builds SDL2_mixer in CI with the Tremor backend for OGG playback.

Previously, it was built with the STB backend which crashes in game.

## Existing issue

When building SDL2_mixer on the 3DS with the Tremor backend, it would usually result in undefined references errors due to the generated CMake configuration not linking libogg. The proposed fix consists in manually setting the `tremor_LINK_LIBRARIES`, declaring the dependency on libogg.