### PR TITLE
Nintendo 3DS fixes

### DIFF
--- a/.github/workflows/n3ds.yml
+++ b/.github/workflows/n3ds.yml
@@ -38,7 +38,7 @@ jobs:
           cmake -S .github/SDL_mixer -B .github/SDL_mixer-build -DCMAKE_TOOLCHAIN_FILE=$DEVKITPRO/cmake/3DS.cmake \
                 -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DSDL2MIXER_DEPS_SHARED=OFF \
                 -DSDL2MIXER_SAMPLES=OFF -DSDL2MIXER_FLAC=OFF -DSDL2MIXER_MIDI=OFF -DSDL2MIXER_MOD=OFF \
-                -DSDL2MIXER_MP3=OFF -DSDL2MIXER_OPUS=OFF -DSDL2MIXER_VORBIS=TREMOR
+                -DSDL2MIXER_MP3=OFF -DSDL2MIXER_OPUS=OFF -DSDL2MIXER_VORBIS=TREMOR -DSDL2MIXER_VORBIS_TREMOR_SHARED=OFF
           cmake --build .github/SDL_mixer-build --config ${{ env.BUILD_TYPE }}
           cmake --install .github/SDL_mixer-build --config ${{ env.BUILD_TYPE }}
 

--- a/src/sdl12main.c
+++ b/src/sdl12main.c
@@ -544,7 +544,7 @@ static void mainLoop(void)
     prev_buttons_state = buttons_state;
     buttons_state = 0;
 
-#if SDL_MAJOR_VERSION >= 2 && ! defined (__NGAGE__) && ! defined (NGAGE_DEBUG) && ! defined (__3DS__)
+#if SDL_MAJOR_VERSION >= 2 && ! defined (__NGAGE__) && ! defined (NGAGE_DEBUG)
     SDL_GameControllerUpdate();
     ReadGamepadInput(&buttons_state);
 

--- a/src/sdl20compat.inc.c
+++ b/src/sdl20compat.inc.c
@@ -1,9 +1,5 @@
 #include<assert.h>
 
-#ifdef __3DS__
-#include <3ds.h>
-#endif
-
 //dummy values
 enum
 {
@@ -206,41 +202,8 @@ static void SDL_Flip(SDL_Surface* screen)
 #endif
     SDL_RenderPresent(sdl2_rendr);
 }
-#if defined(__3DS__)
-#define N3DS_KEY_COUNT 12
-static Uint8 keys[SDL_NUM_SCANCODES] = {SDL_RELEASED};
-const Uint8 *GetN3DSKeystate(int *numkeys) 
-{
-  const static Uint8 keymap[N3DS_KEY_COUNT] = {
-      SDL_SCANCODE_C,      SDL_SCANCODE_X,     SDL_SCANCODE_F9,
-      SDL_SCANCODE_ESCAPE, SDL_SCANCODE_RIGHT, SDL_SCANCODE_LEFT,
-      SDL_SCANCODE_UP,     SDL_SCANCODE_DOWN,  SDL_SCANCODE_D,
-      SDL_SCANCODE_S,      SDL_SCANCODE_C,     SDL_SCANCODE_X,
-  };
-  u32 down, released;
-  int idx;
-  hidScanInput();
-  down = hidKeysDown();
-  released = hidKeysUp();
-  for (idx = 0; idx < N3DS_KEY_COUNT; ++idx) {
-    const Uint8 sdl_key = keymap[idx];
-    u32 key_bit = BIT(idx);
-    if (SDL_RELEASED == keys[sdl_key]) {
-      if (down & key_bit) {
-        keys[sdl_key] = SDL_PRESSED;
-      }
-    } else {
-      if (released & key_bit) {
-        keys[sdl_key] = SDL_RELEASED;
-      }
-    }
-  }
-  return keys;
-}
-#define SDL_GetKeyState GetN3DSKeystate
-#else
+
 #define SDL_GetKeyState SDL_GetKeyboardState
-#endif
 //the above function now returns array indexed by scancodes, so we need to use those constants
 #if defined (__NGAGE__)
 // Reset


### PR DESCRIPTION
## Description

Revert the controls workaround for the Nintendo 3DS as it was indeed an upstream issue that was fixed in https://github.com/libsdl-org/SDL/pull/6522

Moreover, pass the `-DSDL2MIXER_VORBIS_TREMOR_SHARED=OFF` option to SDL_mixer for CI to produce builds with working audio.

## Existing issue

Fixes #13.