### PR TITLE
N3DS: Use 2.26.0 instead of origin/main

### DIFF
--- a/.github/workflows/n3ds.yml
+++ b/.github/workflows/n3ds.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           repository: libsdl-org/SDL
           path: .github/SDL
+          ref: release-2.26.0
       - name: Install SDL2
         run: |
           cmake -S .github/SDL -B .github/SDL-build -DCMAKE_TOOLCHAIN_FILE=$DEVKITPRO/cmake/3DS.cmake \

--- a/cmake/get_SDL2.cmake
+++ b/cmake/get_SDL2.cmake
@@ -18,15 +18,10 @@ macro(get_SDL2 version)
   else()
     find_package(SDL2 QUIET)
     if(NOT SDL2_FOUND)
-      if(NINTENDO_3DS) # TODO: Remove when added in a release
-        set(tag "origin/main")
-      else()
-        set(tag "release-${version}")
-      endif()
       FetchContent_Declare(
         SDL2
         GIT_REPOSITORY https://github.com/libsdl-org/SDL.git
-        GIT_TAG "${tag}")
+        GIT_TAG "release-${version}")
       FetchContent_MakeAvailable(SDL2)
       set(SDL2_LIBRARIES SDL2::SDL2main SDL2::SDL2)
     endif()


### PR DESCRIPTION
With 2.26.0 being out and SDL3 development started on `origin/main`, the workaround should be removed in `get_SDL2` and the CI should be updated to use a specific SDL2 release.