### PR TITLE
CI: Fix Ubuntu inconsistencies.

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -37,6 +37,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Update APT packages (Ubuntu)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt update
+          sudo apt upgrade -y
+
       - name: Install build dependencies (Ubuntu)
         if: runner.os == 'Linux'
         # Considering the large amount of dependencies, cache them to save time from run to run

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -42,7 +42,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get upgrade -y
-
       - name: Install build dependencies (Ubuntu)
         if: runner.os == 'Linux'
         # Considering the large amount of dependencies, cache them to save time from run to run

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -40,8 +40,8 @@ jobs:
       - name: Update APT packages (Ubuntu)
         if: runner.os == 'Linux'
         run: |
-          sudo apt update
-          sudo apt upgrade -y
+          sudo apt-get update
+          sudo apt-get upgrade -y
 
       - name: Install build dependencies (Ubuntu)
         if: runner.os == 'Linux'


### PR DESCRIPTION
By updating packages beforehand, we avoid "random" failures in Ubuntu CI.

Note that Nintendo 3DS CI will fail in this PR, see #16.