### PR TITLE
allow HIGHDPI window

### DIFF
--- a/src/sdl20compat.inc.c
+++ b/src/sdl20compat.inc.c
@@ -30,7 +30,7 @@ static SDL_Surface *SDL_SetVideoMode(int width, int height, int bpp, Uint32 flag
 #if defined (__NGAGE__) || defined (NGAGE_DEBUG)
         sdl2_window = SDL_CreateWindow("", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width, height, 0);
 #else
-        sdl2_window = SDL_CreateWindow("", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width, height, SDL_WINDOW_RESIZABLE);
+        sdl2_window = SDL_CreateWindow("", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, width, height, SDL_WINDOW_ALLOW_HIGHDPI | SDL_WINDOW_RESIZABLE);
 #endif
         if (!sdl2_window)
         {


### PR DESCRIPTION
for Retina screens, for example on Mac or mobile devices.

Reference: https://wiki.libsdl.org/SDL2/SDL_WindowFlags

Have a nice week
midzer